### PR TITLE
Send back status after receiving new code

### DIFF
--- a/src/mlogwatcher/MlogServer.java
+++ b/src/mlogwatcher/MlogServer.java
@@ -3,10 +3,8 @@ package mlogwatcher;
 import arc.Core;
 import arc.input.KeyCode;
 import arc.scene.ui.Dialog;
-import arc.scene.ui.Label;
 import arc.util.Log;
 import arc.util.Nullable;
-import mindustry.Vars;
 import org.java_websocket.WebSocket;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
@@ -17,6 +15,9 @@ import java.net.InetSocketAddress;
 public class MlogServer extends WebSocketServer {
     @Nullable
     private static MlogServer server;
+
+    public static final String STATUS_OK = "ok";
+    public static final String STATUS_NO_PROCESSOR = "no_processor";
 
     MlogServer(int port) {
         super(new InetSocketAddress(port));
@@ -51,7 +52,8 @@ public class MlogServer extends WebSocketServer {
 
     @Override
     public void onMessage(WebSocket conn, String message) {
-        ProcessorUpdater.InsertLogic(message);
+        boolean processorAttached = ProcessorUpdater.InsertLogic(message);
+        conn.send(processorAttached ? STATUS_OK : STATUS_NO_PROCESSOR);
     }
 
     @Override

--- a/src/mlogwatcher/ProcessorUpdater.java
+++ b/src/mlogwatcher/ProcessorUpdater.java
@@ -41,13 +41,14 @@ public class ProcessorUpdater {
         InsertLogic(asmCode);
     }
 
-    public static void InsertLogic(String asmCode) {
+    public static boolean InsertLogic(String asmCode) {
         if (lastTappedLogicBuild == null) {
             Log.warn("cannot find any selected logic block!");
-            return;
+            return false;
         }
 
         lastTappedLogicBuild.configure(LogicBlock.compress(asmCode, lastTappedLogicBuild.relativeConnections()));
         Fx.spawn.at(lastTappedLogicBuild.x, lastTappedLogicBuild.y);
+        return true;
     }
 }


### PR DESCRIPTION
This PR modifies the WebSocket server to send a message back to the client after receiving new code. The message is a plain text status:

- `ok`: the code was injected into the selected processor,
- `no_processor` the code wasn't injected, as there isn't any processor selected.

Fixes #4. I've tested it against a modified client which processes the status messages.