### PR TITLE
refactor: remove unnecessary base64 mlog encoding

### DIFF
--- a/WEBSOCKET_API.md
+++ b/WEBSOCKET_API.md
@@ -48,7 +48,7 @@ This method injects mlog code into the selected processor on the map.
 
 [`UpdateSelectedProcessorParams`](CLASSES.md#class-updateselectedprocessorparams) 
 
-* `code`: a Base-64 encoded text of an mlog program.
+* `code`: the source code of the mlog program.
 
 #### Responses
 
@@ -70,7 +70,7 @@ This method finds all compatible processors on the map and injects the provided 
 
 [`UpdateProcessorsOnMapParams` instance](CLASSES.md#class-updateprocessorsonmapparams)
 
-* `code`: a Base-64 encoded text of an mlog program.
+* `code`: the source code of the mlog program.
 * `program_id`: a [program ID](CLASSES.md#class-programid). Contains a prefix and version numbers. To match, the processor's ID must have the same prefix and a compatible version number.
 * `variableName`: name of the variable which should contain the program ID. The server looks for this variable in processors. The variable name may not be overridden by the mod's configuration.
 * `version_selection`: string. One of: 
@@ -142,7 +142,7 @@ This method doesn't take any parameters (set `params` to `null`).
 * `status`: `success`
 * `result_type`: `mlog_code_result`
 * `result`: [`ProcessorExtractResults`](CLASSES.md#class-processorextractresults) instance containing the following attributes:
-  * `code`: a Base-64 encoded text of the extracted mlog program.
+  * `code`: the source code of the extracted mlog program.
 
 **Errors**
 

--- a/src/mlogwatcher/websocket/api/ProcessorExtractResults.java
+++ b/src/mlogwatcher/websocket/api/ProcessorExtractResults.java
@@ -1,8 +1,5 @@
 package mlogwatcher.websocket.api;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 public class ProcessorExtractResults implements Results {
 
     private String code;
@@ -15,12 +12,10 @@ public class ProcessorExtractResults implements Results {
     }
 
     public String getCode() {
-        byte[] bytes = Base64.getDecoder().decode(code);
-        return new String(bytes, StandardCharsets.UTF_8);
+        return this.code;
     }
 
     public void setCode(String code) {
-        byte[] bytes = code.getBytes(StandardCharsets.UTF_8);
-        this.code = Base64.getEncoder().encodeToString(bytes);
+        this.code = code;
     }
 }

--- a/src/mlogwatcher/websocket/api/UpdateProcessorsOnMapParams.java
+++ b/src/mlogwatcher/websocket/api/UpdateProcessorsOnMapParams.java
@@ -2,9 +2,6 @@ package mlogwatcher.websocket.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 public class UpdateProcessorsOnMapParams implements Params {
     public static final String VERSION_SELECTION_EXACT = "exact";
     public static final String VERSION_SELECTION_COMPATIBLE = "compatible";
@@ -22,13 +19,11 @@ public class UpdateProcessorsOnMapParams implements Params {
     private String versionSelection;
 
     public String getCode() {
-        byte[] bytes = Base64.getDecoder().decode(code);
-        return new String(bytes, StandardCharsets.UTF_8);
+        return code;
     }
 
     public void setCode(String code) {
-        byte[] bytes = code.getBytes(StandardCharsets.UTF_8);
-        this.code = Base64.getEncoder().encodeToString(bytes);
+        this.code = code;
     }
 
     public ProgramId getProgramId() {

--- a/src/mlogwatcher/websocket/api/UpdateSelectedProcessorParams.java
+++ b/src/mlogwatcher/websocket/api/UpdateSelectedProcessorParams.java
@@ -1,19 +1,15 @@
 package mlogwatcher.websocket.api;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 
 public class UpdateSelectedProcessorParams implements Params {
 
     private String code;
 
     public String getCode() {
-        byte[] bytes = Base64.getDecoder().decode(code);
-        return new String(bytes, StandardCharsets.UTF_8);
+        return this.code;
     }
 
     public void setCode(String code) {
-        byte[] bytes = code.getBytes(StandardCharsets.UTF_8);
-        this.code = Base64.getEncoder().encodeToString(bytes);
+        this.code = code;
     }
 }


### PR DESCRIPTION
Despite the documentation saying that mlog code is base64-encoded in request and response messages,
that wasn't the case due to a bug in the implementation. But since using base64 is not really necessary in this case since the mlog code can be encoded just fine by JSON itself, it might be a better idea to change the documentation and make the current behavior official.

**Note**: This pull request does not alter the behavior of the mod compared to its previous version, it just removes effectively dead code and updates the documentation.

Bug explanation (using `UpdateSelectedProcessorParams` as examples):
- client sends base64 encoded mlog
- server receives message
- server starts parsing message
- server assigns values to the `UpdateSelectedProcessorParams` instance
- `UpdateSelectedProcessorParams#setCode` encodes the received code and assigns it to `UpdateSelectedProcessorParams#code`.
- `UpdateSelectedProcessorParams#code` is double encoded.
- `UpdateSelectedProcessorParams#getCode` returns the orginal base64-encoded mlog, not the actual mlog code.

This can be circumvented by making the client send regular mlog code in the `code` field.