### PR TITLE
Fixes #13: observe processor configuration size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To select a processor, tap on it. A golden diamond is drawn around/on a selected
 
 ### Schematics
 
-Schematic needs to be stored in binary format in files having the `.msch` extension. When such a file is created or updated in the watched directory and contains a valid schematic, the schematic is loaded, and `MlogWatcher` tag is added to the schematic, and the schematic is stored in the library. If a schematic with an identical name containing the `MlogWatcher` tag already exists in the library, it is replaced by the imported schematic. Otherwise, the imported schematic is added to the library; if a schematic with the same name already exists, the new one is placed alongside the existing one.
+Schematic needs to be stored in binary format in files having the `.msch` extension. When such a file is created or updated in the watched directory and contains a valid schematic, the schematic is loaded, the `MlogWatcher` tag is added to the schematic, and the schematic is stored in the library. If a schematic with an identical name containing the `MlogWatcher` tag already exists in the library, it is replaced by the imported schematic. Otherwise, the imported schematic is added to the library; if a schematic with the same name already exists, the new one is placed alongside the existing one.
 
 Schematics are updated regardless of the state of the game. When the game is running, only a message is briefly shown in the game. When the game is paused or not active at all, the imported schematic is shown on screen.
 

--- a/WEBSOCKET_API.md
+++ b/WEBSOCKET_API.md
@@ -5,7 +5,7 @@ The mod provides a WebSocket API, which can be used to update logic processors a
 The WebSocket server runs on port `9992` by default, but this can be changed in the configuration. The most recent interface runs on the `/v1` path. For connecting to a game running on a local computer, use the `localhost:9992/v1` URL. (It is also possible to connect to a game running on another device, assuming the connection can be made and isn't blocked by a firewall.)
 
 > [!NOTE]
-> When no path is specified in the URL, the [legacy API](#legacy-api) is used. When any other path is specified, the server doesn't process or respond to the request.
+> When no path is specified in the URL, the [legacy API](#legacy-api) is used. When any path other than `/v1` is specified, the server doesn't process or respond to the request.
 
 The API uses JSON for communication. An instance of the [`Request` class](CLASSES.md#class-request) must be sent to the server. The class has the following attributes:
 
@@ -29,6 +29,7 @@ When `status` is set to `error`, the result type will be set to `text_result`. T
  * `invalid_program_id`: the [program id](CLASSES.md#class-programid) specified in the request is invalid.
  * `invalid_version_selection`: the [version selection]() specified in the request is invalid.
  * `no_processor_attached`: no logic processor was selected in the game.
+ * `code_size_too_large`: the code would cause the processor's configuration size limit to be exceeded.
  * `no_active_map`: no map is currently loaded in the game.
  * `no_processors_found`: no logic processor matching the selection criteria was found.
  * `schematic_import_failed`: the schematic couldn't be imported (possibly because the schematic content is corrupted).
@@ -92,6 +93,7 @@ This method finds all compatible processors on the map and injects the provided 
     * `updated`: the processor was updated successfully.
     * `incompatible_version`: the processor's version number was not matched by `version_selection`.
     * `missing_program_id`: the processor has no program ID at all.
+    * `code_size_too_large`: the code would cause the processor's configuration size limit to be exceeded.
 
 Processors with valid, but not matching program IDs are not included in the response.
 
@@ -179,7 +181,7 @@ Upon error, an `error` response is sent. Errors pertaining to this method are:
 ## Legacy API
 
 > [!NOTE]
-> Do not use the legacy API for new developments. This API is not safe, as the received messages are sent directly to the selected processor without any validations, possibly overwriting the processor's code with incorrect data. 
+> Do not use the legacy API for new development. This API is not safe, as the received messages are sent directly to the selected processor without any validations, possibly overwriting the processor's code with incorrect data. 
 
 The legacy API represents the Websocket interface provided by earlier versions of the mod. It is invoked when no path is specified in the URL.
 

--- a/assets/bundles/bundle.properties
+++ b/assets/bundles/bundle.properties
@@ -21,7 +21,7 @@ mlogwatcher.setting.processorTagVariables=List of processor tag variables (space
 mlogwatcher.setting.noTagVariables=<none - processor tag won't be shown>
 
 mlogwatcher.setting.schematicLibrary=Schematic Library
-mlogwatcher.setting.numberOfSchematics=MlogWatcher schematics in the library:
+mlogwatcher.setting.numberOfSchematics=MlogWatcher schematics in the library: {0}
 mlogwatcher.setting.purgeSchematics=Erase all MlogWatcher schematics
 mlogwatcher.setting.purgeSchematicsPrompt=All schematics imported via Mlog Watcher will be permanently removed from the schematic library.
 

--- a/assets/mod.json
+++ b/assets/mod.json
@@ -4,7 +4,7 @@
   "author": "Sharlottes",
   "description": "The watcher mod for Mlog (Mindustry Logic) programming. Provides a WebSockets API for compilers to write or read mlog code stored in processors and schematics in the schematic library. Supports updating selected processor and schematic library when a file in a local directory changes.",
   "subtitle": "The Mlog watcher mod",
-  "version": "0.4v",
+  "version": "0.5v",
   "main": "mlogwatcher.MlogWatcher",
   "minGameVersion": "154.2",
   "dependencies": [],

--- a/src/mlogwatcher/ProcessorUpdater.java
+++ b/src/mlogwatcher/ProcessorUpdater.java
@@ -17,6 +17,7 @@ import mindustry.world.blocks.logic.LogicBlock;
 import mlogwatcher.websocket.api.LogicProcessor;
 import mlogwatcher.websocket.api.ProcessorUpdateResults;
 import mlogwatcher.websocket.api.ProgramId;
+import mlogwatcher.websocket.api.Response;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,20 +56,26 @@ public class ProcessorUpdater {
         insertLogic(lastTappedLogicBuild, asmCode);
     }
 
-    public static boolean insertLogic(String asmCode) {
+    public static String insertLogic(String asmCode) {
         return insertLogic(lastTappedLogicBuild, asmCode);
     }
 
-    public static boolean insertLogic(LogicBlock.LogicBuild build, String asmCode) {
+    public static String insertLogic(LogicBlock.LogicBuild build, String asmCode) {
         if (build == null || build.dead || !accessible(build)) {
             Log.warn("[MlogWatcher] cannot find any selected logic block!");
-            return false;
+            return Response.ERR_NO_PROCESSOR_ATTACHED;
         }
 
-        build.configure(LogicBlock.compress(asmCode, build.relativeConnections()));
+        byte[] compressed = LogicBlock.compress(asmCode, build.relativeConnections());
+        // Intentionally not using the in-game constant to be compatible with older releases as well
+        if (compressed.length > 16_000) {
+            Log.warn("[MlogWatcher] code size too large!");
+            return Response.ERR_CODE_SIZE_TOO_LARGE;
+        }
+        build.configure(compressed);
         Fx.spawn.at(build.x, build.y);
         Log.info("[MlogWatcher] successfully injected code into logic block");
-        return true;
+        return Response.STATUS_SUCCESS;
     }
 
     public static String extractLogic() {
@@ -106,8 +113,8 @@ public class ProcessorUpdater {
                     updateStatus = LogicProcessor.MISSING_PROGRAM_ID;
                 } else if (oldId.getIdPrefix().equals(newId.getIdPrefix())) {
                     if (shouldUpdate(oldId, newId, versionSelection)) {
-                        insertLogic(logicBuild, asmCode);
-                        updateStatus = LogicProcessor.UPDATED;
+                        String result = insertLogic(logicBuild, asmCode);
+                        updateStatus = Response.isSuccess(result) ? LogicProcessor.UPDATED : result;
                     } else {
                         updateStatus = LogicProcessor.INCOMPATIBLE_VERSION;
                     }

--- a/src/mlogwatcher/Settings.java
+++ b/src/mlogwatcher/Settings.java
@@ -174,6 +174,6 @@ public class Settings {
     }
 
     private static String numberOfSchematicsText() {
-        return Core.bundle.get(Constants.DirectBundles.numberOfSchematics) + SchematicsUpdater.numberOfSchematics();
+        return Core.bundle.format(Constants.DirectBundles.numberOfSchematics, SchematicsUpdater.numberOfSchematics());
     }
 }

--- a/src/mlogwatcher/websocket/MlogServer.java
+++ b/src/mlogwatcher/websocket/MlogServer.java
@@ -96,8 +96,9 @@ public class MlogServer extends WebSocketServer {
 
     private void handleLegacyMessage(WebSocket conn, String message) {
         if (!Core.settings.getBool(Constants.Settings.legacyApiOff)) {
-            boolean processorAttached = ProcessorUpdater.insertLogic(message);
-            conn.send(processorAttached ? STATUS_OK : STATUS_NO_PROCESSOR);
+            String result = ProcessorUpdater.insertLogic(message);
+            // The legacy API doesn't support any error message except "no_processor"
+            conn.send(Response.isSuccess(result) ? STATUS_OK : STATUS_NO_PROCESSOR);
         }
     }
 

--- a/src/mlogwatcher/websocket/UpdateSelectedProcessorHandler.java
+++ b/src/mlogwatcher/websocket/UpdateSelectedProcessorHandler.java
@@ -15,8 +15,8 @@ public class UpdateSelectedProcessorHandler implements MethodHandler {
 
         try {
             UpdateSelectedProcessorParams params = request.getParams();
-            boolean success = ProcessorUpdater.insertLogic(params.getCode());
-            return success ? Response.success() : Response.error(Response.ERR_NO_PROCESSOR_ATTACHED);
+            String result = ProcessorUpdater.insertLogic(params.getCode());
+            return Response.fromResult(result);
         } catch (ClassCastException e) {
             Log.err("[MlogWatcher] unexpected type of parameters", e);
         } catch (IllegalAccessError e) {

--- a/src/mlogwatcher/websocket/api/Response.java
+++ b/src/mlogwatcher/websocket/api/Response.java
@@ -12,6 +12,7 @@ public class Response {
     public static final String ERR_INVALID_PROGRAM_ID = "invalid_program_id";
     public static final String ERR_INVALID_VERSION_SELECTION = "invalid_version_selection";
     public static final String ERR_NO_PROCESSOR_ATTACHED = "no_processor_attached";
+    public static final String ERR_CODE_SIZE_TOO_LARGE = "code_size_too_large";
     public static final String ERR_NO_ACTIVE_MAP = "no_active_map";
     public static final String ERR_NO_PROCESSORS_FOUND = "no_processors_found";
     public static final String ERR_SCHEMATIC_IMPORT_FAILED = "schematic_import_failed";
@@ -65,6 +66,10 @@ public class Response {
         this.result = result;
     }
 
+    public static boolean isSuccess(String result) {
+        return STATUS_SUCCESS.equals(result);
+    }
+
     public Response(String status) {
         this(status, 0, RESULT_TYPE_TEXT, null);
     }
@@ -91,6 +96,10 @@ public class Response {
 
     public static Response error(String result) {
         return new Response(STATUS_ERROR, result);
+    }
+
+    public static Response fromResult(String result) {
+        return isSuccess(result) ? success() : error(result);
     }
 
     // getters & setters


### PR DESCRIPTION
This PR verifies the code being injected into the processor observes the processor configuration size limit (16,000 bytes of compressed code plus link configuration).

To avoid dependency on the newest Mindustry version, the limit is hard-coded into the program and not reused from the Mindustry code-base. In older versions, the limit is not explicitly enforced by the game, but exceeding it causes problems down the line, so it makes sense to enforce it everywhere.

A small change to the formatting of the texts in the settings dialog was made. Documentation was updated. I've also bumped the mod version to 0.5, so release could be made straight away.